### PR TITLE
feat(client): Read credentials from response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the [examples](./examples/basic) directory for complete working examples.
 | onClose            | () => void              | No       | Called when explicitly closed (disconnected)                            |
 | onError            | (error: Error) => void  | No       | Called when a stream or connection error occurs                         |
 
-The `startStreamUrl` endpoint must include `{ conduit: { token, channel_id, url } }` in its response.
+The `startStreamUrl` endpoint can return any response body. It provides the connection details in the `X-Conduit-Token`, `X-Conduit-Channel-Id`, and `X-Conduit-Url` response headers.
 
 ### useStream (React)
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,18 +1,15 @@
 const MAX_SEEN_TRACKING = 2048;
 
-/**
- * Response from the stream initialization endpoint containing
- * authentication and connection details.
- */
-export type StartStreamResponse = {
-  conduit: {
-    /** Authentication token for the stream connection */
-    token: string;
-    /** UUID4 for the stream session */
-    channel_id: string;
-    /** Where the client should connect */
-    url: string;
-  };
+export const CONDUIT_RESPONSE_HEADERS = {
+  token: 'X-Conduit-Token',
+  channelId: 'X-Conduit-Channel-Id',
+  url: 'X-Conduit-Url',
+} as const;
+
+type StreamCredentials = {
+  token: string;
+  channelId: string;
+  url: string;
 };
 
 type BaseEnvelope = {
@@ -113,7 +110,7 @@ export class ConduitClient<T> {
     this.config = config;
   }
 
-  private async startStream(): Promise<StartStreamResponse> {
+  private async startStream(): Promise<StreamCredentials> {
     const response = await fetch(this.config.startStreamUrl, {
       method: 'POST',
       headers: {
@@ -130,13 +127,15 @@ export class ConduitClient<T> {
       throw new Error(`Failed to start stream ${response.statusText}`);
     }
 
-    const data = await response.json();
+    const token = response.headers?.get(CONDUIT_RESPONSE_HEADERS.token);
+    const channelId = response.headers?.get(CONDUIT_RESPONSE_HEADERS.channelId);
+    const url = response.headers?.get(CONDUIT_RESPONSE_HEADERS.url);
 
-    if (!data.conduit?.token || !data.conduit?.channel_id || !data.conduit?.url) {
-      throw new Error('Invalid response from startStream endpoint');
+    if (!token || !channelId || !url) {
+      throw new Error('Missing Conduit response headers from startStream endpoint');
     }
 
-    return data as StartStreamResponse;
+    return { token, channelId, url };
   }
 
   private buildUrl(url: string, token: string, channelId: string): string {
@@ -252,9 +251,7 @@ export class ConduitClient<T> {
     if (this.connecting || this.eventSource) return;
     this.connecting = true;
     try {
-      const {
-        conduit: { token, channel_id, url },
-      } = await this.startStream();
+      const { token, channelId, url } = await this.startStream();
 
       this.tokenExpiresAt = this.getTokenExpiry(token);
 
@@ -263,14 +260,14 @@ export class ConduitClient<T> {
         return;
       }
 
-      if (channel_id !== this.currentChannelId) {
-        this.currentChannelId = channel_id;
+      if (channelId !== this.currentChannelId) {
+        this.currentChannelId = channelId;
         this.lastSeq = undefined;
         this.seenIds.clear();
         this.lastEventId = undefined;
       }
 
-      const conduitUrl = this.buildUrl(url, token, channel_id);
+      const conduitUrl = this.buildUrl(url, token, channelId);
       this.attach(conduitUrl);
     } finally {
       this.connecting = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 export { useStream, type UseStreamOptions } from './useStream';
 export {
   ConduitClient,
+  CONDUIT_RESPONSE_HEADERS,
   type ConduitClientConfig,
-  type StartStreamResponse,
   type StreamEnvelope,
   type ControlEnvelope,
   type StreamPhase,

--- a/tests/client.test.ts
+++ b/tests/client.test.ts
@@ -29,9 +29,21 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
+const conduitHeaders = (
+  token = 'token1',
+  channelId = 'channel1',
+  url = 'https://conduit.example.com/events',
+) =>
+  new Headers({
+    'X-Conduit-Token': token,
+    'X-Conduit-Channel-Id': channelId,
+    'X-Conduit-Url': url,
+  });
+
 const mockSuccessfulFetch = (serverUrl = 'https://conduit.example.com/events', overrides = {}) => {
   global.fetch = vi.fn().mockResolvedValueOnce({
     ok: true,
+    headers: conduitHeaders('token1', 'channel1', serverUrl),
     json: () =>
       Promise.resolve({
         conduit: {
@@ -72,7 +84,26 @@ describe('buildUrl', () => {
 });
 
 describe('startStream validation', () => {
-  it('throws error when conduit object is missing', async () => {
+  it('reads connection details from response headers without parsing the body', async () => {
+    const json = vi.fn();
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      headers: new Headers({
+        'X-Conduit-Token': 'header-token',
+        'X-Conduit-Channel-Id': 'header-channel',
+        'X-Conduit-Url': 'https://conduit.example.com/events',
+      }),
+      json,
+    });
+
+    const client = createClient();
+    await client.connect();
+
+    expect(json).not.toHaveBeenCalled();
+    expect(client['currentChannelId']).toBe('header-channel');
+  });
+
+  it('throws error when Conduit headers are missing', async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: true,
       json: () => Promise.resolve({}),
@@ -80,7 +111,9 @@ describe('startStream validation', () => {
 
     const client = createClient();
 
-    await expect(client.connect()).rejects.toThrow('Invalid response from startStream endpoint');
+    await expect(client.connect()).rejects.toThrow(
+      'Missing Conduit response headers from startStream endpoint',
+    );
   });
 
   it('throws error when token is missing', async () => {
@@ -97,7 +130,9 @@ describe('startStream validation', () => {
 
     const client = createClient();
 
-    await expect(client.connect()).rejects.toThrow('Invalid response from startStream endpoint');
+    await expect(client.connect()).rejects.toThrow(
+      'Missing Conduit response headers from startStream endpoint',
+    );
   });
 
   it('throws error when channel_id is missing', async () => {
@@ -114,7 +149,9 @@ describe('startStream validation', () => {
 
     const client = createClient();
 
-    await expect(client.connect()).rejects.toThrow('Invalid response from startStream endpoint');
+    await expect(client.connect()).rejects.toThrow(
+      'Missing Conduit response headers from startStream endpoint',
+    );
   });
 
   it('throws error when url is missing', async () => {
@@ -131,7 +168,9 @@ describe('startStream validation', () => {
 
     const client = createClient();
 
-    await expect(client.connect()).rejects.toThrow('Invalid response from startStream endpoint');
+    await expect(client.connect()).rejects.toThrow(
+      'Missing Conduit response headers from startStream endpoint',
+    );
   });
 });
 
@@ -139,6 +178,7 @@ describe('startStream headers', () => {
   it('includes custom headers in startStream request', async () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce({
       ok: true,
+      headers: conduitHeaders(),
       json: () =>
         Promise.resolve({
           conduit: {
@@ -174,6 +214,7 @@ describe('startStream headers', () => {
   it('works without custom headers', async () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce({
       ok: true,
+      headers: conduitHeaders(),
       json: () =>
         Promise.resolve({
           conduit: {
@@ -202,6 +243,7 @@ describe('startStream headers', () => {
   it('allows overriding Content-Type header', async () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce({
       ok: true,
+      headers: conduitHeaders(),
       json: () =>
         Promise.resolve({
           conduit: {
@@ -234,6 +276,7 @@ describe('startStream headers', () => {
   it('handles empty headers object', async () => {
     const fetchSpy = vi.fn().mockResolvedValueOnce({
       ok: true,
+      headers: conduitHeaders(),
       json: () =>
         Promise.resolve({
           conduit: {
@@ -270,6 +313,7 @@ describe('channel management', () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
+        headers: conduitHeaders('token1', 'channel1'),
         json: () =>
           Promise.resolve({
             conduit: {
@@ -281,6 +325,7 @@ describe('channel management', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        headers: conduitHeaders('token2', 'channel1'),
         json: () =>
           Promise.resolve({
             conduit: {
@@ -310,6 +355,7 @@ describe('channel management', () => {
       .fn()
       .mockResolvedValueOnce({
         ok: true,
+        headers: conduitHeaders('token1', 'channel1'),
         json: () =>
           Promise.resolve({
             conduit: {
@@ -321,6 +367,7 @@ describe('channel management', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        headers: conduitHeaders('token2', 'channel2'),
         json: () =>
           Promise.resolve({
             conduit: {
@@ -541,6 +588,7 @@ describe('isConnecting', () => {
 
     resolveFetch!({
       ok: true,
+      headers: conduitHeaders(),
       json: () =>
         Promise.resolve({
           conduit: {


### PR DESCRIPTION
Start endpoints often need to return their own domain payload, so requiring every response serializer to embed a Conduit-specific object couples otherwise unrelated APIs to the transport.

Read connection credentials from the standardized `X-Conduit-Token`, `X-Conduit-Channel-Id`, and `X-Conduit-Url` response headers instead. Export the header names for consumers that need to share the contract, and validate the complete header set before opening the stream.